### PR TITLE
fix(settings): trust proxy headers behind Northflank

### DIFF
--- a/census_app/settings.py
+++ b/census_app/settings.py
@@ -156,6 +156,11 @@ X_FRAME_OPTIONS = "DENY"
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
+# When running behind a reverse proxy (e.g., Northflank), trust forwarded proto/host
+# so Django correctly detects HTTPS and constructs absolute URLs without redirect loops.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+
 CSP_DEFAULT_SRC = ("'self'",)
 CSP_STYLE_SRC = (
     "'self'",


### PR DESCRIPTION
- Add SECURE_PROXY_SSL_HEADER and USE_X_FORWARDED_HOST so Django recognizes HTTPS behind NF\n- Prevents SECURE_SSL_REDIRECT loops and ensures correct host in absolute URLs