### PR TITLE
feat(core): add /healthz endpoint for probes

### DIFF
--- a/census_app/core/urls.py
+++ b/census_app/core/urls.py
@@ -6,6 +6,7 @@ app_name = "core"
 
 urlpatterns = [
     path("home", views.home, name="home"),
+    path("healthz", views.healthz, name="healthz"),
     path("profile", views.profile, name="profile"),
     path("signup/", views.signup, name="signup"),
     path("docs/", views.docs_index, name="docs_index"),

--- a/census_app/core/views.py
+++ b/census_app/core/views.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import redirect, render
 
 from census_app.surveys.models import (
@@ -36,6 +36,13 @@ except ImportError:
 
 def home(request):
     return render(request, "core/home.html")
+
+
+def healthz(request):
+    """Lightweight health endpoint for load balancers and readiness probes.
+    Returns 200 OK without auth or redirects.
+    """
+    return HttpResponse("ok", content_type="text/plain")
 
 
 @login_required


### PR DESCRIPTION
- Adds GET /healthz that returns 200 OK for NF readiness/liveness\n- Use this path for health checks instead of / to avoid auth/redirect side-effects