### PR TITLE
Fix staticfiles permission error in production deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN poetry install --only main --no-interaction --no-ansi
 RUN npm run build:css
 
 RUN adduser --disabled-login --gecos "" appuser
+RUN mkdir -p /app/staticfiles /app/media && \
+    chown -R appuser:appuser /app/staticfiles /app/media
 USER appuser
 
 ENV DJANGO_SETTINGS_MODULE=census_app.settings


### PR DESCRIPTION
Create staticfiles and media directories with proper ownership before
switching to non-root user in Dockerfile. This ensures collectstatic
can write to /app/staticfiles during deployment.

Fixes: PermissionError: [Errno 13] Permission denied: '/app/staticfiles'
during collectstatic in Northflank deployment.