### PR TITLE
feat: Add survey deletion with confirmation and improve navigation UX

### DIFF
--- a/census_app/api/views.py
+++ b/census_app/api/views.py
@@ -133,6 +133,28 @@ class SurveyViewSet(viewsets.ModelViewSet):
         # Attach to serializer context for response augmentation
         self._created_key = key
 
+    def perform_destroy(self, instance):
+        """Delete survey with audit logging."""
+        survey_name = instance.name
+        survey_slug = instance.slug
+        organization = instance.organization
+
+        instance.delete()
+
+        # Log deletion
+        AuditLog.objects.create(
+            actor=self.request.user,
+            scope=AuditLog.Scope.SURVEY,
+            survey=None,  # Survey is deleted
+            organization=organization,
+            action=AuditLog.Action.REMOVE,
+            target_user=self.request.user,
+            metadata={
+                "survey_name": survey_name,
+                "survey_slug": survey_slug,
+            },
+        )
+
     @action(
         detail=True,
         methods=["post"],

--- a/census_app/core/templates/core/home.html
+++ b/census_app/core/templates/core/home.html
@@ -22,7 +22,7 @@
       <img src="{{ brand.icon_url }}" alt="{{ brand.icon_alt|default:brand.title }}" class="block h-24 w-24 md:h-40 md:w-40 lg:h-[32vh] lg:w-auto max-w-full object-contain" />
       {% else %}
       <div class="h-24 md:h-40 lg:h-[32vh] w-auto flex items-center justify-start">
-  {% include "components/icons/census_brand.html" with classes="h-full w-auto text-base-content" %}
+  {% include "components/icons/census_brand.html" with classes="h-full w-auto text-primary" %}
       </div>
       {% endif %}
     </div>

--- a/census_app/surveys/templates/surveys/dashboard.html
+++ b/census_app/surveys/templates/surveys/dashboard.html
@@ -20,6 +20,12 @@
   {% endif %}
 {% endblock %}
 {% block title %}{% trans "Dashboard" %} - {{ survey.name }}{% endblock %}
+<div role="alert" class="alert alert-info">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+  </svg>
+  <span>Keep track of survey status, number of responses and control styling.</span>
+</div>
 {% block content %}
 <div class="prose">
   {% trans "Surveys" as bc_surveys %}
@@ -178,5 +184,29 @@
   </details>
 
   {# Group management is available on the Groups page #}
+
+  {# Danger zone - Delete survey #}
+  <details class="collapse collapse-arrow bg-error/10 border border-error/30 mt-6">
+    <summary class="cursor-pointer select-none text-lg font-semibold text-error">
+      {% trans "Danger Zone" %}
+    </summary>
+    <div class="mt-4 p-4">
+      <div class="alert alert-error mb-4">
+        <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <div>
+          <h3 class="font-bold">{% trans "Delete this survey" %}</h3>
+          <p class="text-sm">{% trans "Once deleted, all data, responses, groups, and permissions will be permanently removed. This action cannot be undone." %}</p>
+        </div>
+      </div>
+      <a href="{% url 'surveys:delete' survey.slug %}" class="btn btn-error">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+        {% trans "Delete Survey" %}
+      </a>
+    </div>
+  </details>
 </div>
 {% endblock %}

--- a/census_app/surveys/templates/surveys/delete_confirm.html
+++ b/census_app/surveys/templates/surveys/delete_confirm.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-8 max-w-2xl">
+    <div class="card bg-base-100 shadow-xl border-2 border-error">
+        <div class="card-body">
+            <h2 class="card-title text-error">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                Delete Survey
+            </h2>
+
+            <div class="divider"></div>
+
+            <div class="alert alert-error">
+                <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div>
+                    <h3 class="font-bold">Warning: This action cannot be undone!</h3>
+                    <p class="text-sm">You are about to permanently delete the survey:</p>
+                    <p class="font-mono text-sm mt-2 font-bold">{{ survey.name }}</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                <p class="text-base-content/80 mb-4">
+                    Deleting this survey will permanently remove:
+                </p>
+                <ul class="list-disc list-inside space-y-2 text-base-content/70 ml-4">
+                    <li>All survey data and responses</li>
+                    <li>All associated groups and questions</li>
+                    <li>All collection and publication records</li>
+                    <li>All access permissions and tokens</li>
+                </ul>
+            </div>
+
+            <form method="post" class="mt-6">
+                {% csrf_token %}
+
+                <div class="form-control w-full">
+                    <label class="label">
+                        <span class="label-text font-semibold">
+                            To confirm deletion, please type the survey name exactly as shown above:
+                        </span>
+                    </label>
+                    <input
+                        type="text"
+                        name="confirm_name"
+                        placeholder="Type survey name here"
+                        class="input input-bordered w-full {% if error %}input-error{% endif %}"
+                        value="{{ confirm_name|default:'' }}"
+                        autocomplete="off"
+                        required
+                    />
+                    {% if error %}
+                        <label class="label">
+                            <span class="label-text-alt text-error">
+                                {% if error == "confirmation_required" %}
+                                    You must type the survey name to confirm deletion.
+                                {% elif error == "name_mismatch" %}
+                                    The name you entered does not match. Please type exactly: <strong>{{ survey.name }}</strong>
+                                {% endif %}
+                            </span>
+                        </label>
+                    {% endif %}
+                </div>
+
+                <div class="card-actions justify-end mt-6 gap-2">
+                    <a href="{% url 'surveys:dashboard' survey.slug %}" class="btn btn-ghost">
+                        Cancel
+                    </a>
+                    <button type="submit" class="btn btn-error">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                        Delete Survey Permanently
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/census_app/surveys/urls.py
+++ b/census_app/surveys/urls.py
@@ -42,6 +42,7 @@ urlpatterns = [
     path("<slug:slug>/thank-you/", views.survey_thank_you, name="thank_you"),
     path("<slug:slug>/", views.survey_detail, name="detail"),
     path("<slug:slug>/dashboard/", views.survey_dashboard, name="dashboard"),
+    path("<slug:slug>/delete/", views.survey_delete, name="delete"),
     path(
         "<slug:slug>/dashboard/publish",
         views.survey_publish_update,

--- a/census_app/templates/base.html
+++ b/census_app/templates/base.html
@@ -75,24 +75,48 @@
         </a>
       </div>
       <div class="flex-none">
-        <ul class="menu menu-horizontal">
+        <ul class="menu menu-horizontal px-1">
           {% if user.is_authenticated %}
             <li><a href="/surveys">Surveys</a></li>
             {% if can_manage_any_users %}
               <li><a href="{% url 'surveys:user_management_hub' %}">User management</a></li>
             {% endif %}
-            <li><a href="/profile">Profile</a></li>
             <li><a href="{% url 'core:docs_index' %}">Documentation</a></li>
             <li>
-              <form method="post" action="/accounts/logout/">
-                {% csrf_token %}
-                <button type="submit" class="btn btn-sm normal-case">Logout</button>
-              </form>
+              <div class="dropdown dropdown-end">
+                <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
+                  <div class="w-10 rounded-full bg-primary/10 flex items-center justify-center">
+                    <span class="text-lg font-semibold text-primary">{{ user.username|slice:":1"|upper }}</span>
+                  </div>
+                </div>
+                <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+                  <li class="menu-title">
+                    <span class="text-base-content">{{ user.username }}</span>
+                  </li>
+                  <li><a href="/profile">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                    </svg>
+                    Profile
+                  </a></li>
+                  <li>
+                    <form method="post" action="/accounts/logout/" class="p-0">
+                      {% csrf_token %}
+                      <button type="submit" class="w-full text-left flex items-center gap-2">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                        </svg>
+                        Logout
+                      </button>
+                    </form>
+                  </li>
+                </ul>
+              </div>
             </li>
           {% else %}
+            <li><a href="{% url 'core:docs_index' %}">Documentation</a></li>
             <li><a href="/accounts/login/">Login</a></li>
             <li><a href="/signup/">Sign up</a></li>
-            <li><a href="{% url 'core:docs_index' %}">Documentation</a></li>
           {% endif %}
         </ul>
       </div>

--- a/tests/test_survey_deletion.py
+++ b/tests/test_survey_deletion.py
@@ -1,0 +1,281 @@
+"""
+Tests for survey deletion functionality.
+
+Ensures only authorized users (owner or org admin) can delete surveys via API and webapp.
+"""
+
+import json
+
+from django.contrib.auth import get_user_model
+import pytest
+
+from census_app.surveys.models import (
+    AuditLog,
+    Organization,
+    OrganizationMembership,
+    Survey,
+)
+
+User = get_user_model()
+TEST_PASSWORD = "test-pass"
+
+
+def get_auth_header(client, username: str, password: str) -> dict:
+    """Helper to get JWT auth header."""
+    resp = client.post(
+        "/api/token",
+        data=json.dumps({"username": username, "password": password}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.content
+    access = resp.json()["access"]
+    return {"HTTP_AUTHORIZATION": f"Bearer {access}"}
+
+
+@pytest.mark.django_db
+class TestSurveyDeletionAPI:
+    """Test survey deletion via REST API."""
+
+    def setup_test_data(self):
+        """Create test users, org, and surveys."""
+        owner = User.objects.create_user(username="owner", password=TEST_PASSWORD)
+        admin = User.objects.create_user(username="admin", password=TEST_PASSWORD)
+        creator = User.objects.create_user(username="creator", password=TEST_PASSWORD)
+        viewer = User.objects.create_user(username="viewer", password=TEST_PASSWORD)
+        outsider = User.objects.create_user(username="outsider", password=TEST_PASSWORD)
+
+        org = Organization.objects.create(name="Test Org", owner=owner)
+        OrganizationMembership.objects.create(
+            organization=org, user=admin, role=OrganizationMembership.Role.ADMIN
+        )
+        OrganizationMembership.objects.create(
+            organization=org, user=creator, role=OrganizationMembership.Role.CREATOR
+        )
+        OrganizationMembership.objects.create(
+            organization=org, user=viewer, role=OrganizationMembership.Role.VIEWER
+        )
+
+        survey = Survey.objects.create(
+            owner=owner, organization=org, name="Test Survey", slug="test-survey"
+        )
+
+        return {
+            "owner": owner,
+            "admin": admin,
+            "creator": creator,
+            "viewer": viewer,
+            "outsider": outsider,
+            "org": org,
+            "survey": survey,
+        }
+
+    def test_owner_can_delete_survey(self, client):
+        """Survey owner can delete their survey."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+        url = f"/api/surveys/{survey.pk}/"
+
+        hdrs = get_auth_header(client, "owner", TEST_PASSWORD)
+        resp = client.delete(url, **hdrs)
+
+        assert resp.status_code == 204
+        assert not Survey.objects.filter(pk=survey.pk).exists()
+
+        # Check audit log
+        log = AuditLog.objects.filter(
+            action=AuditLog.Action.REMOVE, scope=AuditLog.Scope.SURVEY
+        ).first()
+        assert log is not None
+        assert log.actor == data["owner"]
+        assert log.metadata["survey_name"] == "Test Survey"
+        assert log.metadata["survey_slug"] == "test-survey"
+
+    def test_org_admin_can_delete_survey(self, client):
+        """Org admin can delete surveys in their org."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+        url = f"/api/surveys/{survey.pk}/"
+
+        hdrs = get_auth_header(client, "admin", TEST_PASSWORD)
+        resp = client.delete(url, **hdrs)
+
+        assert resp.status_code == 204
+        assert not Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_creator_cannot_delete_others_survey(self, client):
+        """Creator role cannot delete surveys they don't own."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+        url = f"/api/surveys/{survey.pk}/"
+
+        hdrs = get_auth_header(client, "creator", TEST_PASSWORD)
+        resp = client.delete(url, **hdrs)
+
+        assert resp.status_code == 403
+        assert Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_viewer_cannot_delete_survey(self, client):
+        """Viewer role cannot delete surveys."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+        url = f"/api/surveys/{survey.pk}/"
+
+        hdrs = get_auth_header(client, "viewer", TEST_PASSWORD)
+        resp = client.delete(url, **hdrs)
+
+        assert resp.status_code == 403
+        assert Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_outsider_cannot_delete_survey(self, client):
+        """User not in org cannot delete survey."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+        url = f"/api/surveys/{survey.pk}/"
+
+        hdrs = get_auth_header(client, "outsider", TEST_PASSWORD)
+        resp = client.delete(url, **hdrs)
+
+        assert resp.status_code == 403
+        assert Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_unauthenticated_cannot_delete_survey(self, client):
+        """Unauthenticated users cannot delete surveys."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+        url = f"/api/surveys/{survey.pk}/"
+
+        resp = client.delete(url)
+
+        assert resp.status_code in (401, 403)
+        assert Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_creator_can_delete_own_survey(self, client):
+        """Creator can delete their own survey."""
+        data = self.setup_test_data()
+        creator = data["creator"]
+        org = data["org"]
+
+        # Create survey owned by creator
+        survey = Survey.objects.create(
+            owner=creator, organization=org, name="Creator Survey", slug="creator-survey"
+        )
+
+        url = f"/api/surveys/{survey.pk}/"
+        hdrs = get_auth_header(client, "creator", TEST_PASSWORD)
+        resp = client.delete(url, **hdrs)
+
+        assert resp.status_code == 204
+        assert not Survey.objects.filter(pk=survey.pk).exists()
+
+
+@pytest.mark.django_db
+class TestSurveyDeletionWebApp:
+    """Test survey deletion via web interface."""
+
+    def setup_test_data(self):
+        """Create test users, org, and surveys."""
+        owner = User.objects.create_user(username="owner", password=TEST_PASSWORD)
+        admin = User.objects.create_user(username="admin", password=TEST_PASSWORD)
+        creator = User.objects.create_user(username="creator", password=TEST_PASSWORD)
+
+        org = Organization.objects.create(name="Test Org", owner=owner)
+        OrganizationMembership.objects.create(
+            organization=org, user=admin, role=OrganizationMembership.Role.ADMIN
+        )
+        OrganizationMembership.objects.create(
+            organization=org, user=creator, role=OrganizationMembership.Role.CREATOR
+        )
+
+        survey = Survey.objects.create(
+            owner=owner, organization=org, name="Test Survey", slug="test-survey"
+        )
+
+        return {
+            "owner": owner,
+            "admin": admin,
+            "creator": creator,
+            "org": org,
+            "survey": survey,
+        }
+
+    def test_delete_without_confirmation_fails(self, client):
+        """Delete without name confirmation should fail."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+
+        client.login(username="owner", password=TEST_PASSWORD)
+        url = f"/surveys/{survey.slug}/delete/"
+
+        # POST without confirmation name
+        resp = client.post(url, {})
+
+        assert resp.status_code == 400
+        assert Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_delete_with_wrong_name_fails(self, client):
+        """Delete with incorrect name confirmation should fail."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+
+        client.login(username="owner", password=TEST_PASSWORD)
+        url = f"/surveys/{survey.slug}/delete/"
+
+        # POST with wrong name
+        resp = client.post(url, {"confirm_name": "Wrong Name"})
+
+        assert resp.status_code == 400
+        assert Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_owner_can_delete_with_confirmation(self, client):
+        """Owner can delete survey with correct name confirmation."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+
+        client.login(username="owner", password=TEST_PASSWORD)
+        url = f"/surveys/{survey.slug}/delete/"
+
+        # POST with correct name
+        resp = client.post(url, {"confirm_name": "Test Survey"})
+
+        assert resp.status_code == 302  # Redirect after success
+        assert not Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_admin_can_delete_with_confirmation(self, client):
+        """Org admin can delete survey with correct name confirmation."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+
+        client.login(username="admin", password=TEST_PASSWORD)
+        url = f"/surveys/{survey.slug}/delete/"
+
+        # POST with correct name
+        resp = client.post(url, {"confirm_name": "Test Survey"})
+
+        assert resp.status_code == 302
+        assert not Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_creator_cannot_delete_others_survey(self, client):
+        """Creator cannot delete survey they don't own."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+
+        client.login(username="creator", password=TEST_PASSWORD)
+        url = f"/surveys/{survey.slug}/delete/"
+
+        # POST with correct name but no permission
+        resp = client.post(url, {"confirm_name": "Test Survey"})
+
+        assert resp.status_code == 403
+        assert Survey.objects.filter(pk=survey.pk).exists()
+
+    def test_unauthenticated_redirects_to_login(self, client):
+        """Unauthenticated users are redirected to login."""
+        data = self.setup_test_data()
+        survey = data["survey"]
+
+        url = f"/surveys/{survey.slug}/delete/"
+        resp = client.post(url, {"confirm_name": "Test Survey"})
+
+        assert resp.status_code == 302
+        assert "/login/" in resp.url
+        assert Survey.objects.filter(pk=survey.pk).exists()

--- a/tests/test_survey_deletion.py
+++ b/tests/test_survey_deletion.py
@@ -157,7 +157,10 @@ class TestSurveyDeletionAPI:
 
         # Create survey owned by creator
         survey = Survey.objects.create(
-            owner=creator, organization=org, name="Creator Survey", slug="creator-survey"
+            owner=creator,
+            organization=org,
+            name="Creator Survey",
+            slug="creator-survey",
         )
 
         url = f"/api/surveys/{survey.pk}/"


### PR DESCRIPTION
- Add API deletion endpoint with audit logging
  * Implement perform_destroy in SurveyViewSet
  * Use existing OrgOwnerOrAdminPermission (owner or org admin only)
  * Create audit log with REMOVE action

- Add webapp deletion view with name confirmation
  * Create survey_delete view with GET/POST handling
  * Require exact survey name match for confirmation
  * Return 400 error if validation fails
  * Redirect to home with success message after deletion

- Add comprehensive test coverage (13 tests, all passing)
  * API tests: owner, admin, creator, viewer, outsider, unauthenticated
  * Webapp tests: confirmation validation, permissions, redirects
  * Verify audit logging for deletions

- Add delete UI to survey dashboard
  * Create beautiful delete confirmation template
  * Add Danger Zone section to dashboard
  * Warning alerts about permanent deletion
  * Input field requiring exact survey name

- Improve navigation bar UX
  * Replace misaligned login button with inline links
  * Add user dropdown menu with avatar (username initial)
  * Move Profile link from navbar to user dropdown
  * Add icons to Profile and Logout menu items
  * Clean alignment for all navigation elements

All 150 tests passing including 13 new deletion tests